### PR TITLE
Use new icons for steps and escalator

### DIFF
--- a/src/layers.js
+++ b/src/layers.js
@@ -127,6 +127,49 @@ export const layers = [
     }
   },
   {
+    id: "indoor-transportation-poi",
+    "type": "symbol",
+    "source-layer": "transportation",
+    "filter": [
+      "all",
+      [
+        "in",
+        "$type",
+        "Point",
+        "LineString"
+      ],
+      [
+        "in",
+        "class",
+        "steps",
+        "elevator",
+        "escalator"
+      ]
+    ],
+    "layout": {
+      "icon-image": [
+        "case",
+        [
+          "has",
+          "conveying"
+        ],
+        "indoorequal-escalator",
+        [
+          "concat",
+          [
+            "literal",
+            "indoorequal-"
+          ],
+          [
+            "get",
+            "class"
+          ]]
+      ],
+      "symbol-placement": "line-center",
+      "icon-rotation-alignment": "viewport"
+    }
+  },
+  {
     id: "indoor-poi-rank1",
     ...commonPoi,
     "filter": [

--- a/test/mapbox-gl-indoorequal.test.js
+++ b/test/mapbox-gl-indoorequal.test.js
@@ -33,8 +33,8 @@ describe('IndoorEqual', () => {
     const indoorEqual = new IndoorEqual(map, { apiKey: 'myapikey' });
     expect(addSource.mock.calls.length).toEqual(1);
     expect(addSource.mock.calls[0]).toEqual(['indoorequal', { type: 'vector', url: 'https://tiles.indoorequal.org/?key=myapikey' }]);
-    expect(addLayer.mock.calls.length).toEqual(9);
-    expect(setFilter.mock.calls.length).toEqual(9);
+    expect(addLayer.mock.calls.length).toEqual(10);
+    expect(setFilter.mock.calls.length).toEqual(10);
   });
 
   it('customize the tiles url', () => {
@@ -58,8 +58,8 @@ describe('IndoorEqual', () => {
     expect(setFilter.mock.calls.length).toEqual(0);
     on.load();
     expect(addSource.mock.calls.length).toEqual(1);
-    expect(addLayer.mock.calls.length).toEqual(9);
-    expect(setFilter.mock.calls.length).toEqual(9);
+    expect(addLayer.mock.calls.length).toEqual(10);
+    expect(setFilter.mock.calls.length).toEqual(10);
   });
 
   it('allow to customize the layers', () => {


### PR DESCRIPTION
I added a new layer `indoor-transportation-poi`. This layer will add a new POI for steps and escalators (as point or line).

Preview:
![image](https://user-images.githubusercontent.com/5153882/88311269-f4e46100-cd10-11ea-8a21-3635b2d41ea5.png)

# Requirements

- indoorequal/indoorequal.org#19
- ~~You should update indoor tiles. Transportation layer should take care of escalators (conveying=*).~~ There are three ways to do it:
    - Replace the class=steps by class=escalator when conveying
    - Add a new attribute name `type=escalator` or `conveying=yes` for escalators (**already done**)
    - Add a new attribute named `icon` or `iconname` or `maki` with the name of the icon (i.e. `steps`, `escalator`....) (I prefer this one because the style will be cleaner and there will always be edge cases...)

Edit: I did't see the conveying attribute :sweat_smile: style updated !