### PR TITLE
Update colors for areas (private/room/ground)

### DIFF
--- a/src/layers.js
+++ b/src/layers.js
@@ -42,7 +42,17 @@ export const layers = [
       ]
     ],
     paint: {
-      "fill-color": "white"
+      "fill-color": [
+        "case",
+        // if private
+        ["all", ["has", "access"], ["in", ["get", "access"], ["literal", ["no", "private"]]]],
+        "#F2F1F0",
+        // if POI
+        ["all", ["has", "is_poi"], ["==", ["get", "is_poi"], true]],
+        "#D4EDFF",
+        // default
+        "#fdfcfa"
+      ]
     }
   },
   {


### PR DESCRIPTION
I chose beige `#fdfcfa` for the ground, blue `#D4EDFF` for rooms and red `#ffE6E6` for private access.

![image](https://user-images.githubusercontent.com/5153882/88380803-87364480-cda5-11ea-9e80-da3fb660f3e1.png)

## Requirements

This PR uses indoorequal/indoorequal#11 but can work without the PR (only private access will be shown).

If you prefer other shades, I can show you more examples.

I found something, [relation/6056803](https://www.openstreetmap.org/relation/6056803) is in blue (is_poi=true). IDK if this should be an area or room :man_shrugging: (amenity=parking)